### PR TITLE
Added parallel safe keyword to function definitions

### DIFF
--- a/postgis-vt-util.sql
+++ b/postgis-vt-util.sql
@@ -18,7 +18,8 @@ __Returns:__ `float[]` - an array of 4 floats, `{xmin, ymin, xmax, ymax}`
 ******************************************************************************/
 create or replace function Bounds (g geometry, srid integer = null)
     returns float[]
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 begin
     if srid is not null then
@@ -48,7 +49,8 @@ __Returns:__ `integer`
 ******************************************************************************/
 create or replace function CleanInt (i text)
     returns integer
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 begin
     return cast(cast(i as float) as integer);
@@ -74,7 +76,8 @@ __Returns:__ `numeric`
 ******************************************************************************/
 create or replace function CleanNumeric (i text)
     returns numeric
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $$
 begin
     return cast(cast(i as float) as numeric);
@@ -124,7 +127,8 @@ create or replace function LabelGrid (
         grid_size numeric
     )
     returns text
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 begin
     if grid_size <= 0 then
@@ -167,7 +171,8 @@ __Returns:__ `geometry` - The largest single part of the input geometry.
 ******************************************************************************/
 create or replace function LargestPart (g geometry)
     returns geometry
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 begin
     -- Non-multi geometries can just pass through
@@ -225,7 +230,8 @@ create or replace function LineLabel (
         g geometry
     )
     returns boolean
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 begin
     if zoom > 20 or ST_Length(g) = 0 then
@@ -273,7 +279,8 @@ create or replace function MakeArc (
         srid integer default null
     )
     returns geometry
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 begin
     return ST_CurveToLine(ST_GeomFromText(
@@ -305,7 +312,8 @@ __Returns:__ `geometry`
 ******************************************************************************/
 create or replace function MercBuffer (g geometry, distance numeric)
     returns geometry
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 begin
     return ST_Buffer(
@@ -338,7 +346,8 @@ create or replace function MercDWithin (
         distance numeric
     )
     returns boolean
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 begin
     return ST_Dwithin(
@@ -365,7 +374,8 @@ __Returns:__ `numeric`
 ******************************************************************************/
 create or replace function MercLength (g geometry)
     returns numeric
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 begin
     return ST_Length(g) * cos(radians(ST_Y(ST_Transform(ST_Centroid(g),4326))));
@@ -386,7 +396,8 @@ __Returns:__ `geometry(polygon)`
 ******************************************************************************/
 create or replace function OrientedEnvelope (g geometry)
     returns geometry(polygon)
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 declare
     p record;
@@ -434,7 +445,8 @@ __Returns:__ `geometry` - a polygon or multipolygon
 ******************************************************************************/
 create or replace function Sieve (g geometry, area_threshold float)
     returns geometry
-    language sql immutable as
+    language sql immutable
+    parallel safe as
 $func$
     with exploded as (
         -- First use ST_Dump to explode the input multipolygon
@@ -454,7 +466,8 @@ $func$;
 
 create or replace function Sieve (g geometry, area_threshold integer)
     returns geometry
-    language sql immutable as
+    language sql immutable
+    parallel safe as
 $func$
     with exploded as (
         -- First use ST_Dump to explode the input multipolygon
@@ -498,7 +511,8 @@ create or replace function SmartShrink(
         simplify boolean = false
     )
     returns geometry
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 declare
     full_area float := ST_Area(geom);
@@ -540,7 +554,8 @@ __Returns:__ `geometry(polygon)`
 ******************************************************************************/
 create or replace function TileBBox (z int, x int, y int, srid int = 3857)
     returns geometry
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 declare
     max numeric := 20037508.34;
@@ -588,7 +603,8 @@ UPDATE city_park SET geom_label = ToPoint(geom);
 ******************************************************************************/
 create or replace function ToPoint (g geometry)
     returns geometry(point)
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 begin
     g := ST_MakeValid(g);
@@ -634,7 +650,8 @@ UPDATE water_polygons SET geom = ST_Simplify(geom, ZRes(10));
 create or replace function ZRes (z integer)
     returns float
     returns null on null input
-    language sql immutable as
+    language sql immutable
+    parallel safe as
 $func$
 select (40075016.6855785/(256*2^z));
 $func$;
@@ -642,7 +659,8 @@ $func$;
 create or replace function ZRes (z float)
     returns float
     returns null on null input
-    language sql immutable as
+    language sql immutable
+    parallel safe as
 $func$
 select (40075016.6855785/(256*2^z));
 $func$;
@@ -675,6 +693,7 @@ create or replace function z (numeric)
   returns integer
   language sql
   immutable
+  parallel safe
   returns null on null input
 as $func$
 select

--- a/src/Bounds.sql
+++ b/src/Bounds.sql
@@ -18,7 +18,8 @@ __Returns:__ `float[]` - an array of 4 floats, `{xmin, ymin, xmax, ymax}`
 ******************************************************************************/
 create or replace function Bounds (g geometry, srid integer = null)
     returns float[]
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 begin
     if srid is not null then

--- a/src/CleanInt.sql
+++ b/src/CleanInt.sql
@@ -11,7 +11,8 @@ __Returns:__ `integer`
 ******************************************************************************/
 create or replace function CleanInt (i text)
     returns integer
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 begin
     return cast(cast(i as float) as integer);

--- a/src/CleanNumeric.sql
+++ b/src/CleanNumeric.sql
@@ -11,7 +11,8 @@ __Returns:__ `numeric`
 ******************************************************************************/
 create or replace function CleanNumeric (i text)
     returns numeric
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $$
 begin
     return cast(cast(i as float) as numeric);

--- a/src/LabelGrid.sql
+++ b/src/LabelGrid.sql
@@ -35,7 +35,8 @@ create or replace function LabelGrid (
         grid_size numeric
     )
     returns text
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 begin
     if grid_size <= 0 then

--- a/src/LargestPart.sql
+++ b/src/LargestPart.sql
@@ -21,7 +21,8 @@ __Returns:__ `geometry` - The largest single part of the input geometry.
 ******************************************************************************/
 create or replace function LargestPart (g geometry)
     returns geometry
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 begin
     -- Non-multi geometries can just pass through

--- a/src/LineLabel.sql
+++ b/src/LineLabel.sql
@@ -21,7 +21,8 @@ create or replace function LineLabel (
         g geometry
     )
     returns boolean
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 begin
     if zoom > 20 or ST_Length(g) = 0 then

--- a/src/MakeArc.sql
+++ b/src/MakeArc.sql
@@ -33,7 +33,8 @@ create or replace function MakeArc (
         srid integer default null
     )
     returns geometry
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 begin
     return ST_CurveToLine(ST_GeomFromText(

--- a/src/MercBuffer.sql
+++ b/src/MercBuffer.sql
@@ -16,7 +16,8 @@ __Returns:__ `geometry`
 ******************************************************************************/
 create or replace function MercBuffer (g geometry, distance numeric)
     returns geometry
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 begin
     return ST_Buffer(

--- a/src/MercDWithin.sql
+++ b/src/MercDWithin.sql
@@ -20,7 +20,8 @@ create or replace function MercDWithin (
         distance numeric
     )
     returns boolean
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 begin
     return ST_Dwithin(

--- a/src/MercLength.sql
+++ b/src/MercLength.sql
@@ -13,7 +13,8 @@ __Returns:__ `numeric`
 ******************************************************************************/
 create or replace function MercLength (g geometry)
     returns numeric
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 begin
     return ST_Length(g) * cos(radians(ST_Y(ST_Transform(ST_Centroid(g),4326))));

--- a/src/OrientedEnvelope.sql
+++ b/src/OrientedEnvelope.sql
@@ -11,7 +11,8 @@ __Returns:__ `geometry(polygon)`
 ******************************************************************************/
 create or replace function OrientedEnvelope (g geometry)
     returns geometry(polygon)
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 declare
     p record;

--- a/src/Sieve.sql
+++ b/src/Sieve.sql
@@ -12,7 +12,8 @@ __Returns:__ `geometry` - a polygon or multipolygon
 ******************************************************************************/
 create or replace function Sieve (g geometry, area_threshold float)
     returns geometry
-    language sql immutable as
+    language sql immutable
+    parallel safe as
 $func$
     with exploded as (
         -- First use ST_Dump to explode the input multipolygon
@@ -32,7 +33,8 @@ $func$;
 
 create or replace function Sieve (g geometry, area_threshold integer)
     returns geometry
-    language sql immutable as
+    language sql immutable
+    parallel safe as
 $func$
     with exploded as (
         -- First use ST_Dump to explode the input multipolygon

--- a/src/SmartShrink.sql
+++ b/src/SmartShrink.sql
@@ -23,7 +23,8 @@ create or replace function SmartShrink(
         simplify boolean = false
     )
     returns geometry
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 declare
     full_area float := ST_Area(geom);

--- a/src/TileBBox.sql
+++ b/src/TileBBox.sql
@@ -16,7 +16,8 @@ __Returns:__ `geometry(polygon)`
 ******************************************************************************/
 create or replace function TileBBox (z int, x int, y int, srid int = 3857)
     returns geometry
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 declare
     max numeric := 20037508.34;

--- a/src/ToPoint.sql
+++ b/src/ToPoint.sql
@@ -23,7 +23,8 @@ UPDATE city_park SET geom_label = ToPoint(geom);
 ******************************************************************************/
 create or replace function ToPoint (g geometry)
     returns geometry(point)
-    language plpgsql immutable as
+    language plpgsql immutable
+    parallel safe as
 $func$
 begin
     g := ST_MakeValid(g);

--- a/src/Z.sql
+++ b/src/Z.sql
@@ -25,6 +25,7 @@ create or replace function z (numeric)
   returns integer
   language sql
   immutable
+  parallel safe
   returns null on null input
 as $func$
 select

--- a/src/ZRes.sql
+++ b/src/ZRes.sql
@@ -23,7 +23,8 @@ UPDATE water_polygons SET geom = ST_Simplify(geom, ZRes(10));
 create or replace function ZRes (z integer)
     returns float
     returns null on null input
-    language sql immutable as
+    language sql immutable
+    parallel safe as
 $func$
 select (40075016.6855785/(256*2^z));
 $func$;
@@ -31,7 +32,8 @@ $func$;
 create or replace function ZRes (z float)
     returns float
     returns null on null input
-    language sql immutable as
+    language sql immutable
+    parallel safe as
 $func$
 select (40075016.6855785/(256*2^z));
 $func$;


### PR DESCRIPTION
Since Postgres 9.6 the `PARALLEL SAFE` modifiers for function definition enables the execution of queries using one or more workers in parallel (more details [here](https://www.postgresql.org/docs/current/parallel-safety.html)).

This straight forward PR adds this modifier to this repo functions to avoid them potentially blocking parallel execution when present.

I've done tests on all functions to ensure they don't block parallel executions with the following procedure:

* Created a sample database on a `postgres:12` Docker container with Postgis 3 installed
* Created a sample table `points` with 1M random points and a random `kpi` integer column
* Imported the layer `ne_10m_admin_1_states_provinces` from Natural Earth to have also a multipolygon table
* Relaxed the conditions for parallel execution:
```
[local] postgres@bench=#  set parallel_setup_cost = 10;
SET
Time: 0.322 ms
[local] postgres@bench=# set parallel_tuple_cost = 0.001;
SET
```

* Run sample queries with the keyword enabled until the parallel execution was activated
* Removed the keyword and run the same query for comparison.

The tests below shared are just meant to showcase that `PARALLEL SAFE` can help the faster execution of queries and is not an indicator of the improvement introduced since there are many factors that can affect that.

It's worth noting that this makes these functions only available for [Postgres 9.6](https://www.postgresql.org/docs/9.6/sql-createfunction.html) onwards so maybe we could consider having both versions in separated folders. Let me know if that would make sense to modify the PR that way.

<details><summary>Query examples</summary>

For each query, the execution time in milliseconds with and without the `PARALLEL SAFE` keyword is shared.

### MakeArc

    explain analyze 
    select makearc(geom_lag, geom, geom_lead)
    from (
            select lag(geom) over (partition by kpi % 3 order by kpi) geom_lag,
                    geom,
                    lead(geom) over (partition by kpi % 3 order by kpi) geom_lead
            from points
    ) a 
    union all
    select makearc(geom_lag, geom, geom_lead)
    from (
            select lag(geom) over (partition by kpi % 4 order by kpi) geom_lag,
                    geom,
                    lead(geom) over (partition by kpi % 4 order by kpi) geom_lead
            from points
    ) a;

- With parallel: 1148
- Without parallel: 19395

### MercBuffer

    explain analyze verbose 
    select count(*) 
    from points 
    where st_area(mercbuffer(geom,kpi)) > kpi^10;

- With parallel: 8942
- Without parallel: 25351

### MercDWithin

    explain analyze verbose 
    select count(*) 
    from points 
    where
    MercDWithin(
            st_transform(geom,3857),
            st_transform(
                    ST_SetSRID(
                            ST_MakePoint( -71.1043443253471,42.3150676015829)
                            ,4326)
                    ,3857)
            ,100000);

- With parallel: 1222
- Without parallel: 2885

### MercLength

    explain analyze verbose 
    select count(*) 
    from points 
    where
    MercLength(
            ST_MakeLine(
                    st_transform(geom,3857),
                    st_transform(
                            ST_SetSRID(ST_MakePoint(-71,42),4326)
                            ,3857)
            )
    ) > kpi^10;

- With parallel: 2043
- Without parallel: 4978

### OrientedEnvelope

    explain analyze  
    select sum(r) 
    from
    (
            select sum(st_area(orientedenvelope(geom))) as r
            from points 
            group by kpi % 50000
            union all
            select sum(st_area(orientedenvelope(geom))) as r
            from points 
            group by kpi % 70000
    ) a;

- With parallel: 8727
- Without parallel: 22693

### Sieve

    explain analyze
    select sum(st_area(sieve(geom,0.1)))
    from countries
    where iso_a2 like 'ES'
    union all
    select sum(st_area(sieve(geom,0.1)))
    from countries
    where iso_a2 like 'IT';

- With parallel: 8368
- Without parallel: 12244

### SmartShrink

    explain analyze
    select sum(st_area(smartshrink(geom,0.1)))
    from countries where ogc_fid % 7 = 0
    UNION ALL
    select sum(st_area(smartshrink(geom,0.1)))
    from countries where ogc_fid % 5 = 0;

- With parallel: 15129
- Without parallel: 21061

### TileBBox

    explain analyze
    select count(*)
    from countries
    where st_centroid(geom) && tilebbox(6,28,26)
    union
    select count(*)
    from points
    where st_centroid(geom) && tilebbox(6,28,27);

- With parallel: 470
- Without parallel: 879

### ToPoint

    explain analyze
    select count(*)
    from countries
    where ToPoint(geom) && tilebbox(6,28,26)
    union
    select count(*)
    from points
    where ToPoint(geom) && tilebbox(6,28,27);

- With parallel: 3857
- Without: 4948

</details>

