### PR TITLE
Make CleanInt CleanNumeric parallel safe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,37 @@
+dist: xenial
 language: node_js
 node_js:
-  - "0.10"
-sudo: false
-addons:
-  postgresql: 9.6
-  apt:
-    packages:
-    - postgresql-9.6-postgis-2.3
-before_install:
-- psql -U postgres -c "create database testing_postgis_vt_util"
-- psql -U postgres -d testing_postgis_vt_util -c "create extension postgis"
+- lts/*
+
+sudo: required
+
+env:
+  global:
+    - PGUSER=postgres
+    - PGDATABASE=postgres
+    - PGOPTIONS='-c client_min_messages=NOTICE'
+    - PGPORT=5432
+
+jobs:
+  include:
+    - env: POSTGRESQL_VERSION="9.6" POSTGIS_VERSION="2.5"
+    - env: POSTGRESQL_VERSION="10" POSTGIS_VERSION="2.5"
+    - env: POSTGRESQL_VERSION="11" POSTGIS_VERSION="2.5"
+    - env: POSTGRESQL_VERSION="12" POSTGIS_VERSION="2.5"
+    - env: POSTGRESQL_VERSION="12" POSTGIS_VERSION="3"
+
 script:
-- npm test
+  - sudo service postgresql stop;
+  - sudo apt-get remove postgresql* -y
+  - sudo apt-get install -y --allow-unauthenticated --no-install-recommends --no-install-suggests postgresql-$POSTGRESQL_VERSION postgresql-client-$POSTGRESQL_VERSION postgresql-server-dev-$POSTGRESQL_VERSION postgresql-common
+  - if [[ $POSTGRESQL_VERSION == '9.6' ]]; then sudo apt-get install -y postgresql-contrib-9.6; fi;
+  - sudo apt-get install -y --allow-unauthenticated postgresql-$POSTGRESQL_VERSION-postgis-$POSTGIS_VERSION postgresql-$POSTGRESQL_VERSION-postgis-$POSTGIS_VERSION-scripts postgis
+  - sudo pg_dropcluster --stop $POSTGRESQL_VERSION main
+  - sudo rm -rf /etc/postgresql/$POSTGRESQL_VERSION /var/lib/postgresql/$POSTGRESQL_VERSION
+  - sudo pg_createcluster -u postgres $POSTGRESQL_VERSION main -- --auth-local trust --auth-host password
+  - sudo /etc/init.d/postgresql start $POSTGRESQL_VERSION || sudo journalctl -xe
+  - sudo psql -U postgres -c "create database testing_postgis_vt_util"
+  - sudo psql -U postgres -d testing_postgis_vt_util -c "create extension postgis"
+  - sudo psql -U postgres -d testing_postgis_vt_util -c "select version()"
+  - sudo psql -U postgres -d testing_postgis_vt_util -c "select postgis_version()"
+  - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ jobs:
     - env: POSTGRESQL_VERSION="12" POSTGIS_VERSION="3"
 
 script:
+  - set -e
   - sudo service postgresql stop;
   - sudo apt-get remove postgresql* -y
   - sudo apt-get install -y --allow-unauthenticated --no-install-recommends --no-install-suggests postgresql-$POSTGRESQL_VERSION postgresql-client-$POSTGRESQL_VERSION postgresql-server-dev-$POSTGRESQL_VERSION postgresql-common

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ node_js:
   - "0.10"
 sudo: false
 addons:
-  postgresql: 9.3
+  postgresql: 9.6
+  apt:
+    packages:
+    - postgresql-9.6-postgis-2.3
 before_install:
 - psql -U postgres -c "create database testing_postgis_vt_util"
 - psql -U postgres -d testing_postgis_vt_util -c "create extension postgis"

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,4 @@ script:
   - sudo psql -U postgres -d testing_postgis_vt_util -c "select version()"
   - sudo psql -U postgres -d testing_postgis_vt_util -c "select postgis_version()"
   - npm test
+

--- a/postgis-vt-util.sql
+++ b/postgis-vt-util.sql
@@ -47,21 +47,27 @@ __Parameters:__
 
 __Returns:__ `integer`
 ******************************************************************************/
-create or replace function CleanInt (i text)
-    returns integer
-    language plpgsql immutable
-    parallel safe as
+create or replace function CleanInt (i text) returns integer as
 $func$
-begin
-    return cast(cast(i as float) as integer);
-exception
-    when invalid_text_representation then
-        return null;
-    when numeric_value_out_of_range then
-        return null;
-end;
-$func$;
-
+select case
+            when test[1] in ('','.') then null
+            else
+                case
+                    when cast(test[1] as numeric) > 2147483647 then null
+                    when cast(test[1] as numeric) < -2147483648 then null
+                    else cast(cast(test[1] as float) as integer)
+                end
+        end as result
+from (
+    select array_agg(i) as test
+    from (
+        select (regexp_matches($1,'^[\ ]*?([-+]?[0-9]*\.?[0-9]*?(e[-+]?[0-9]+)?)[\ ]*?$','i'))[1] i
+    )  t
+) _;
+$func$
+language sql 
+strict immutable cost 50
+parallel safe;
 
 /******************************************************************************
 ### CleanNumeric ###
@@ -74,20 +80,23 @@ __Parameters:__
 
 __Returns:__ `numeric`
 ******************************************************************************/
-create or replace function CleanNumeric (i text)
-    returns numeric
-    language plpgsql immutable
-    parallel safe as
-$$
-begin
-    return cast(cast(i as float) as numeric);
-exception
-    when invalid_text_representation then
-        return null;
-    when numeric_value_out_of_range then
-        return null;
-end;
-$$;
+create or replace function CleanNumeric (i text) returns numeric as
+$func$
+select case
+            when test[1] in ('','.') then null
+            else cast(cast(test[1] as float) as numeric)
+        end as result
+from (
+    select array_agg(i) as test
+    from (
+        select (regexp_matches($1,'^[\ ]*?([-+]?[0-9]*\.?[0-9]*?(e[-+]?[0-9]+)?)[\ ]*?$','i'))[1] i
+    )  t
+) _;
+$func$
+language sql 
+strict immutable cost 50
+parallel safe;
+
 
 
 /******************************************************************************

--- a/src/CleanInt.sql
+++ b/src/CleanInt.sql
@@ -9,19 +9,25 @@ __Parameters:__
 
 __Returns:__ `integer`
 ******************************************************************************/
-create or replace function CleanInt (i text)
-    returns integer
-    language plpgsql immutable
-    parallel safe as
+create or replace function CleanInt (i text) returns integer as
 $func$
-begin
-    return cast(cast(i as float) as integer);
-exception
-    when invalid_text_representation then
-        return null;
-    when numeric_value_out_of_range then
-        return null;
-end;
-$func$;
-
+select case
+            when test[1] in ('','.') then null
+            else
+                case
+                    when cast(test[1] as numeric) > 2147483647 then null
+                    when cast(test[1] as numeric) < -2147483648 then null
+                    else cast(cast(test[1] as float) as integer)
+                end
+        end as result
+from (
+    select array_agg(i) as test
+    from (
+        select (regexp_matches($1,'^[\ ]*?([-+]?[0-9]*\.?[0-9]*?(e[-+]?[0-9]+)?)[\ ]*?$','i'))[1] i
+    )  t
+) _;
+$func$
+language sql 
+strict immutable cost 50
+parallel safe;
 

--- a/src/CleanNumeric.sql
+++ b/src/CleanNumeric.sql
@@ -9,19 +9,22 @@ __Parameters:__
 
 __Returns:__ `numeric`
 ******************************************************************************/
-create or replace function CleanNumeric (i text)
-    returns numeric
-    language plpgsql immutable
-    parallel safe as
-$$
-begin
-    return cast(cast(i as float) as numeric);
-exception
-    when invalid_text_representation then
-        return null;
-    when numeric_value_out_of_range then
-        return null;
-end;
-$$;
+create or replace function CleanNumeric (i text) returns numeric as
+$func$
+select case
+            when test[1] in ('','.') then null
+            else cast(cast(test[1] as float) as numeric)
+        end as result
+from (
+    select array_agg(i) as test
+    from (
+        select (regexp_matches($1,'^[\ ]*?([-+]?[0-9]*\.?[0-9]*?(e[-+]?[0-9]+)?)[\ ]*?$','i'))[1] i
+    )  t
+) _;
+$func$
+language sql 
+strict immutable cost 50
+parallel safe;
+
 
 

--- a/test/sql-test.sh
+++ b/test/sql-test.sh
@@ -116,7 +116,7 @@ tf MercLength "ST_GeomFromText('LINESTRING(0 8500000, 10000 8500000)', 900913)" 
 
 # OrientedEnvelope (results differ from postgis 2 to 3)
 oriented_envelope_expect="POLYGON((8 12,10 10,0 0,-2 2,8 12))"
-if [ "${POSTGIS_VERSION}" -eq "3" ]
+if [ "${POSTGIS_VERSION}" = "3" ]
 then
     oriented_envelope_expect="POLYGON((2.308 -1.538,0 0,8 12,10.308 10.462,2.308 -1.538))"
 fi

--- a/test/sql-test.sh
+++ b/test/sql-test.sh
@@ -114,11 +114,15 @@ tf MercLength "ST_GeomFromText('LINESTRING(0 0, 10000 0)', 900913)" \
 tf MercLength "ST_GeomFromText('LINESTRING(0 8500000, 10000 8500000)', 900913)" \
     "4932.24215371697"
 
-# OrientedEnvelope
-tf ST_AsText "ST_SnapToGrid(ST_Centroid(OrientedEnvelope(ST_GeomFromText('LINESTRING(0 0, 10 10, 8 12)'))),0.001)" \
-    "POINT(5.154 5.231)"
-tf round "ST_Area(ST_OrientedEnvelope(ST_GeomFromText('LINESTRING(0 0, 10 10, 8 12)')))::numeric" "4" \
-    "40.0000"
+# OrientedEnvelope (results differ from postgis 2 to 3)
+oriented_envelope_expect="POLYGON((8 12,10 10,0 0,-2 2,8 12))"
+if [ "${POSTGIS_VERSION}" -eq "3" ]
+then
+    oriented_envelope_expect="POLYGON((2.308 -1.538,0 0,8 12,10.308 10.462,2.308 -1.538))"
+fi
+
+tf ST_AsText "ST_SnapToGrid(OrientedEnvelope(ST_GeomFromText('LINESTRING(0 0, 10 10, 8 12)')),0.001)" \
+    "${oriented_envelope_expect}"
 
 # Sieve
 tf ST_AsText "Sieve(ST_GeomFromText('MULTIPOLYGON(\

--- a/test/sql-test.sh
+++ b/test/sql-test.sh
@@ -11,15 +11,24 @@ $psqld -f "$(dirname "$0")/../postgis-vt-util.sql" &> /dev/null
 
 function tf() {
     # tf (test a function)
-    # Usage: tf function_name argument expected-output
+    # Usage: tf function_name argument1 optional-argument-2 expected-output
     runcount=$((runcount+1))
-    result=$($psqld -c "COPY (SELECT $1($2)) TO STDOUT;")
-    if [[ "$result" == "$3" ]]; then
-        echo -e "ok $runcount - $1($2)"
+    func=$1
+    arg=$2
+    if [ "$#" -eq 4 ]; then
+        arg="$2,$3"
+        expected=$4
+    else
+        expected=$3
+    fi
+
+    result=$($psqld -c "COPY (SELECT $func($arg)) TO STDOUT;")
+    if [[ "$result" == "$expected" ]]; then
+        echo -e "ok $runcount - $func($arg)"
         passcount=$((passcount+1))
     else
         echo "not ok $runcount - $1($2)"
-        echo "    expected: '$3'"
+        echo "    expected: '$expected'"
         echo "    actual: '$result'"
         failcount=$((failcount+1))
     fi
@@ -31,23 +40,33 @@ echo "1..$testtotal"
 # Bounds
 tf Bounds "ST_GeomFromText('LINESTRING(100 100, 300 300)', 3857)" \
     "{100,100,300,300}"
-tf Bounds "ST_GeomFromText('LINESTRING(100 100, 300 300)', 3857), 4326" \
-    "{0.000898315284119521,0.00089831528408666,0.00269494585235856,0.0026949458513567}"
+tf "" "select array_agg(i) from \
+    (select round(unnest(Bounds(ST_GeomFromText('LINESTRING(100 100, 300 300)', 3857), 4326))::numeric,8) as i) _" \
+    "{0.00089832,0.00089832,0.00269495,0.00269495}"
 
 # CleanInt
-tf CleanInt "'123'"            "123"
+tf CleanInt "'.'"              "\\N"
+tf CleanInt "''"               "\\N"
 tf CleanInt "'foobar'"         "\\N"
+tf CleanInt "'9999999999'"     "\\N"  # out of range, returns null
+tf CleanInt "'-2147483649'"    "\\N"  # one less than the smallest possible int
 tf CleanInt "'2147483647'"     "2147483647"  # largest possible int
 tf CleanInt "'-2147483648'"    "-2147483648"  # smallest possible int
-tf CleanInt "'9999999999'"     "\\N"  # out of range, returns null
 tf CleanInt "'123.456'"        "123"  # round down
 tf CleanInt "'456.789'"        "457"  # round up
+tf CleanInt "'  456.789  '"    "457"  # round up with trimming
 
 # CleanNumeric
-tf CleanNumeric "'123'"            "123"
+tf CleanNumeric "'.'"              "\\N"
+tf CleanNumeric "''"               "\\N"
 tf CleanNumeric "'foobar'"         "\\N"
+tf CleanNumeric "'9999999999'"     "9999999999"
+tf CleanNumeric "'-9999999999'"    "-9999999999"
+tf CleanNumeric "'123'"            "123"
 tf CleanNumeric "'123.456'"        "123.456"
 tf CleanNumeric "'456.789'"        "456.789"
+tf CleanNumeric "'  456.789   '"   "456.789"
+tf CleanNumeric "'456.789e2'"      "45678.9"
 
 # LabelGrid
 tf LabelGrid "ST_GeomFromText('POINT(100 -100)',900913), 64*9.5546285343" \
@@ -74,14 +93,14 @@ tf LineLabel "14, 'Foobar', ST_GeomFromText('LINESTRING(0 0, 0 300)',900913)" "f
 tf LineLabel "15, 'Foobar', ST_GeomFromText('LINESTRING(0 0, 0 300)',900913)" "t"
 
 # MakeArc
-tf floor "ST_Length(MakeArc(ST_MakePoint(0,0), ST_MakePoint(20,10), ST_MakePoint(40,0)))" \
-    "46"
+tf round "ST_Length(MakeArc(ST_MakePoint(0,0), ST_MakePoint(20,10), ST_MakePoint(40,0)))::numeric" 4 \
+    "46.3601"
 
 # MercBuffer
-tf floor "ST_Area(MercBuffer(ST_GeomFromText('LINESTRING(0 0, 1000 1000)', 900913), 500))" \
-    "2194574"
-tf floor "ST_Area(MercBuffer(ST_GeomFromText('POINT(0 8500000)', 900913), 500))" \
-    "3207797"
+tf round "ST_Area(MercBuffer(ST_GeomFromText('LINESTRING(0 0, 1000 1000)', 900913), 500))::numeric" 4 \
+    "2194574.8596"
+tf round "ST_Area(MercBuffer(ST_GeomFromText('POINT(0 8500000)', 900913), 500))::numeric" 4 \
+    "3207797.4344"
 
 # MercDWithin
 tf MercDWithin "ST_GeomFromText('POINT(0 0)',3857), ST_GeomFromText('POINT(60 0)',3857), 50.0" \
@@ -96,8 +115,10 @@ tf MercLength "ST_GeomFromText('LINESTRING(0 8500000, 10000 8500000)', 900913)" 
     "4932.24215371697"
 
 # OrientedEnvelope
-tf ST_AsText "OrientedEnvelope(ST_GeomFromText('LINESTRING(0 0, 10 10, 8 12)'))" \
-    "POLYGON((8 12,10 10,0 0,-2 2,8 12))"
+tf ST_AsText "ST_SnapToGrid(ST_Centroid(OrientedEnvelope(ST_GeomFromText('LINESTRING(0 0, 10 10, 8 12)'))),0.001)" \
+    "POINT(5.154 5.231)"
+tf round "ST_Area(ST_OrientedEnvelope(ST_GeomFromText('LINESTRING(0 0, 10 10, 8 12)')))::numeric" "4" \
+    "40.0000"
 
 # Sieve
 tf ST_AsText "Sieve(ST_GeomFromText('MULTIPOLYGON(\
@@ -107,10 +128,10 @@ tf ST_AsText "Sieve(ST_GeomFromText('MULTIPOLYGON(\
     "MULTIPOLYGON(((0 0,0 100,100 100,100 0,0 0),(50 50,60 50,60 60,50 60,50 50)),((300 300,300 350,350 350,350 300,300 300)))"
 
 # SmartShrink
-tf floor "ST_Area(SmartShrink(ST_Buffer(ST_MakePoint(0,0),5000),0.5,true))" \
-    "44602035"
-tf floor "ST_Area(SmartShrink(ST_Buffer(ST_MakePoint(0,0),5000),0.5,false))" \
-    "49222695"
+tf round "ST_Area(SmartShrink(ST_Buffer(ST_MakePoint(0,0),5000),0.5,true))::numeric" 4 \
+    "44602035.2490"
+tf round "ST_Area(SmartShrink(ST_Buffer(ST_MakePoint(0,0),5000),0.5,false))::numeric" 4 \
+    "49222695.3598"
 
 # TileBBox
 tf ST_AsText "ST_SnapToGrid(TileBBox(0,0,0),0.01)" \
@@ -133,7 +154,7 @@ tf ToPoint "ST_GeomFromText('MULTIPOLYGON(((0 0, 10 0, 10 10, 0 10, 0 0)))',9009
 tf ToPoint "ST_GeomFromText('MULTIPOLYGON(((0 0, 10 0, 10 10, 0 10, 0 0)), ((20 20, 30 20, 30 30, 20 30, 20 20)))',900913)" \
     "010100002031BF0D0000000000000014400000000000001440"
 tf ST_AsText "ToPoint(ST_GeomFromText('POLYGON((50 5,10 8,10 10,100 190,150 30,150 10,50 5))',900913))" \
-    "POINT(91.328125 97.5)"
+    "POINT(92.5 110)"
 
 
 # Z
@@ -144,9 +165,9 @@ tf Z "0" "\\N"
 tf Z "NULL" "\\N"
 
 # ZRes
-tf ZRes "0" "156543.033928041"
-tf ZRes "19" "0.29858214173897"
-tf ZRes "0.5" "110692.640838034"
+tf round  "ZRes(0)::numeric" "4" "156543.0339"
+tf round  "ZRes(19)::numeric" "4" "0.2986"
+tf round "ZRes(0.5)::numeric" "4" "110692.6408"
 tf ZRes "NULL" "\\N"
 
 if [[ $failcount -eq 0 ]]; then


### PR DESCRIPTION
I realized that I skipped `CleanInt` and `CleanNumeric` on my [last PR](#1) :disappointed:. These two functions implemented the same approach as the [`as_numeric`](https://github.com/openmaptiles/openmaptiles/blob/master/layers/building/building.sql#L4-L14) on OpenMapTiles repo, with the only difference being that these return `NULL` instead of `-1`. The approach of using an exception avoids running them in parallel.

Hence, I decided to bring the regular expression approach to these functions I proposed on https://github.com/openmaptiles/openmaptiles/pull/728. Here there is already a testing mechanism, so I added more checks to ensure more cases are covered. I also improved a bit the tests to allow compare rounded results against a given number of decimals, instead of using `floor`.

Finally, I updated the Travis configuration, since the current one was not working properly. This took more than expected (in fact ended up almost using the same configuration used at [CartoDB/cartodb-postgresql](https://github.com/CartoDB/cartodb-postgresql/blob/master/.travis.yml), but the outcome is good in my opinion, since we now can test all the functions in PostGIS 2.5 on Postgres 9.6, 10, 11, and 12 and PostGIS 3 on 12. You can see the build execution in my [Travis account](https://travis-ci.org/jsanz/postgis-vt-util).

I also found another issue, the function `OrientedEnvelope`, equivalent to  PostGIS 3 [`ST_OrientedEnvelope`](https://postgis.net/docs/ST_OrientedEnvelope.html) but implemented in SQL, yields different results in PostGIS 2.5 and 3. I haven't put time debugging the algorithm, we may want to open a new issue for this, but not sure about how much is worth, being PostGIS 3 the current stable release.

If this PR is merged, we can then make OpenMapTiles `as_numeric` to be just a wrapper to return a `-1`, or if it makes more sense, just replace the function to use `CleanNumeric` I actually prefer a function like this to return a `null` value instead of a value that is a valid input.

cc. @nyurik 