### PR TITLE
Fix CleanNumeric and CleanInt edge case crashes

### DIFF
--- a/postgis-vt-util.sql
+++ b/postgis-vt-util.sql
@@ -50,7 +50,7 @@ __Returns:__ `integer`
 create or replace function CleanInt (i text) returns integer as
 $func$
 select case
-            when test[1] in ('', '.', '-') then null
+            when test[1] in ('', '.', '-', '+') then null
             else
                 case
                     when cast(test[1] as numeric) > 2147483647 then null
@@ -83,7 +83,7 @@ __Returns:__ `numeric`
 create or replace function CleanNumeric (i text) returns numeric as
 $func$
 select case
-            when test[1] in ('', '.', '-') then null
+            when test[1] in ('', '.', '-', '+') then null
             else cast(cast(test[1] as float) as numeric)
         end as result
 from (

--- a/postgis-vt-util.sql
+++ b/postgis-vt-util.sql
@@ -50,7 +50,7 @@ __Returns:__ `integer`
 create or replace function CleanInt (i text) returns integer as
 $func$
 select case
-            when test[1] in ('','.') then null
+            when test[1] in ('', '.', '-') then null
             else
                 case
                     when cast(test[1] as numeric) > 2147483647 then null
@@ -61,11 +61,11 @@ select case
 from (
     select array_agg(i) as test
     from (
-        select (regexp_matches($1,'^[\ ]*?([-+]?[0-9]*\.?[0-9]*?(e[-+]?[0-9]+)?)[\ ]*?$','i'))[1] i
-    )  t
+        select (regexp_matches($1, '^[\ ]*?([-+]?[0-9]*\.?[0-9]*?(e[-+]?[0-9]+)?)[\ ]*?$', 'i'))[1] i
+    ) t
 ) _;
 $func$
-language sql 
+language sql
 strict immutable cost 50
 parallel safe;
 
@@ -83,17 +83,17 @@ __Returns:__ `numeric`
 create or replace function CleanNumeric (i text) returns numeric as
 $func$
 select case
-            when test[1] in ('','.') then null
+            when test[1] in ('', '.', '-') then null
             else cast(cast(test[1] as float) as numeric)
         end as result
 from (
     select array_agg(i) as test
     from (
-        select (regexp_matches($1,'^[\ ]*?([-+]?[0-9]*\.?[0-9]*?(e[-+]?[0-9]+)?)[\ ]*?$','i'))[1] i
-    )  t
+        select (regexp_matches($1, '^[\ ]*?([-+]?[0-9]*\.?[0-9]*?(e[-+]?[0-9]+)?)[\ ]*?$', 'i'))[1] i
+    ) t
 ) _;
 $func$
-language sql 
+language sql
 strict immutable cost 50
 parallel safe;
 

--- a/postgis-vt-util.sql
+++ b/postgis-vt-util.sql
@@ -48,27 +48,19 @@ __Parameters:__
 __Returns:__ `integer`
 ******************************************************************************/
 create or replace function CleanInt (i text) returns integer as
-$func$
-select case
-            when test[1] in ('', '.', '-', '+') then null
-            else
-                case
-                    when cast(test[1] as numeric) > 2147483647 then null
-                    when cast(test[1] as numeric) < -2147483648 then null
-                    else cast(cast(test[1] as float) as integer)
-                end
-        end as result
-from (
-    select array_agg(i) as test
-    from (
-        select (regexp_matches($1, '^[\ ]*?([-+]?[0-9]*\.?[0-9]*?(e[-+]?[0-9]+)?)[\ ]*?$', 'i'))[1] i
-    ) t
-) _;
-$func$
-language sql
-strict immutable cost 50
+$body$
+declare n numeric := substring(i from '^\s*([-+]?(?=\d|\.\d)\d*(?:\.\d*)?(?:[Ee][-+]?\d+)?)\s*$');
+begin
+    if n not between -2147483648 and 2147483647 then
+        return null;
+    else
+        return n::float8::integer;
+    end if;
+end;
+$body$
+language plpgsql
+strict immutable cost 20
 parallel safe;
-
 /******************************************************************************
 ### CleanNumeric ###
 
@@ -81,24 +73,14 @@ __Parameters:__
 __Returns:__ `numeric`
 ******************************************************************************/
 create or replace function CleanNumeric (i text) returns numeric as
-$func$
-select case
-            when test[1] in ('', '.', '-', '+') then null
-            else cast(cast(test[1] as float) as numeric)
-        end as result
-from (
-    select array_agg(i) as test
-    from (
-        select (regexp_matches($1, '^[\ ]*?([-+]?[0-9]*\.?[0-9]*?(e[-+]?[0-9]+)?)[\ ]*?$', 'i'))[1] i
-    ) t
-) _;
-$func$
-language sql
-strict immutable cost 50
+$body$
+begin
+    return substring(i from '^\s*([-+]?(?=\d|\.\d)\d*(?:\.\d*)?(?:[Ee][-+]?\d+)?)\s*$')::numeric;
+end;
+$body$
+language plpgsql
+strict immutable cost 20
 parallel safe;
-
-
-
 /******************************************************************************
 ### LabelGrid ###
 

--- a/src/CleanInt.sql
+++ b/src/CleanInt.sql
@@ -12,7 +12,7 @@ __Returns:__ `integer`
 create or replace function CleanInt (i text) returns integer as
 $func$
 select case
-            when test[1] in ('', '.') then null
+            when test[1] in ('', '.', '-') then null
             else
                 case
                     when cast(test[1] as numeric) > 2147483647 then null
@@ -27,7 +27,7 @@ from (
     ) t
 ) _;
 $func$
-language sql 
+language sql
 strict immutable cost 50
 parallel safe;
 

--- a/src/CleanInt.sql
+++ b/src/CleanInt.sql
@@ -10,24 +10,16 @@ __Parameters:__
 __Returns:__ `integer`
 ******************************************************************************/
 create or replace function CleanInt (i text) returns integer as
-$func$
-select case
-            when test[1] in ('', '.', '-') then null
-            else
-                case
-                    when cast(test[1] as numeric) > 2147483647 then null
-                    when cast(test[1] as numeric) < -2147483648 then null
-                    else cast(cast(test[1] as float) as integer)
-                end
-        end as result
-from (
-    select array_agg(i) as test
-    from (
-        select (regexp_matches($1, '^[\ ]*?([-+]?[0-9]*\.?[0-9]*?(e[-+]?[0-9]+)?)[\ ]*?$', 'i'))[1] i
-    ) t
-) _;
-$func$
-language sql
-strict immutable cost 50
+$body$
+declare n numeric := substring(i from '^\s*([-+]?(?=\d|\.\d)\d*(?:\.\d*)?(?:[Ee][-+]?\d+)?)\s*$');
+begin
+    if n not between -2147483648 and 2147483647 then
+        return null;
+    else
+        return n::float8::integer;
+    end if;
+end;
+$body$
+language plpgsql
+strict immutable cost 20
 parallel safe;
-

--- a/src/CleanNumeric.sql
+++ b/src/CleanNumeric.sql
@@ -12,7 +12,7 @@ __Returns:__ `numeric`
 create or replace function CleanNumeric (i text) returns numeric as
 $func$
 select case
-            when test[1] in ('', '.') then null
+            when test[1] in ('', '.', '-') then null
             else cast(cast(test[1] as float) as numeric)
         end as result
 from (
@@ -22,7 +22,7 @@ from (
     ) t
 ) _;
 $func$
-language sql 
+language sql
 strict immutable cost 50
 parallel safe;
 

--- a/src/CleanNumeric.sql
+++ b/src/CleanNumeric.sql
@@ -10,21 +10,11 @@ __Parameters:__
 __Returns:__ `numeric`
 ******************************************************************************/
 create or replace function CleanNumeric (i text) returns numeric as
-$func$
-select case
-            when test[1] in ('', '.', '-') then null
-            else cast(cast(test[1] as float) as numeric)
-        end as result
-from (
-    select array_agg(i) as test
-    from (
-        select (regexp_matches($1, '^[\ ]*?([-+]?[0-9]*\.?[0-9]*?(e[-+]?[0-9]+)?)[\ ]*?$', 'i'))[1] i
-    ) t
-) _;
-$func$
-language sql
-strict immutable cost 50
+$body$
+begin
+    return substring(i from '^\s*([-+]?(?=\d|\.\d)\d*(?:\.\d*)?(?:[Ee][-+]?\d+)?)\s*$')::numeric;
+end;
+$body$
+language plpgsql
+strict immutable cost 20
 parallel safe;
-
-
-

--- a/test/sql-test.sh
+++ b/test/sql-test.sh
@@ -51,14 +51,32 @@ tf CleanInt "'-'"              "\\N"
 tf CleanInt "'+'"              "\\N"
 tf CleanInt "'foobar'"         "\\N"
 tf CleanInt "'9999999999'"     "\\N"  # out of range, returns null
-tf CleanInt "'-2147483649'"    "\\N"  # one less than the smallest possible int
-tf CleanInt "'2147483647'"     "2147483647"  # largest possible int
-tf CleanInt "'-2147483648'"    "-2147483648"  # smallest possible int
+tf CleanInt "'-9999999999'"    "\\N"
+tf CleanInt "'e'"              "\\N"
+tf CleanInt "'E'"              "\\N"
+tf CleanInt "'e2'"             "\\N"
+tf CleanInt "'E2'"             "\\N"
+tf CleanInt "'.e'"             "\\N"
+tf CleanInt "'.E'"             "\\N"
+tf CleanInt "'1e'"             "\\N"
+tf CleanInt "'1E'"             "\\N"
+tf CleanInt "'1.e'"            "\\N"
+tf CleanInt "'1.E'"            "\\N"
+tf CleanInt "'.e2'"            "\\N"
+tf CleanInt "'.E2'"            "\\N"
+tf CleanInt "'123'"            "123"
+tf CleanInt "'+42'"            "42"   # allowed plus symbol
 tf CleanInt "'123.456'"        "123"  # round down
 tf CleanInt "'456.789'"        "457"  # round up
 tf CleanInt "'  456.789  '"    "457"  # round up with trimming
-tf CleanInt "'+42'"            "42"   # allowed plus symbol
+tf CleanInt "'456.789e2'"      "45679"  # int with exp, round up
 tf CleanInt "'+42.123'"        "42"
+# INT range check
+tf CleanInt "'-2147483649'"    "\\N"  # one less than the smallest possible int
+tf CleanInt "'2147483648'"     "\\N"  # one more than the largest possible int
+tf CleanInt "'2147483647'"     "2147483647"  # largest possible int
+tf CleanInt "'-2147483648'"    "-2147483648"  # smallest possible int
+
 
 # CleanNumeric
 tf CleanNumeric "'.'"              "\\N"
@@ -66,6 +84,18 @@ tf CleanNumeric "''"               "\\N"
 tf CleanNumeric "'-'"              "\\N"
 tf CleanNumeric "'+'"              "\\N"
 tf CleanNumeric "'foobar'"         "\\N"
+tf CleanNumeric "'e'"              "\\N"
+tf CleanNumeric "'E'"              "\\N"
+tf CleanNumeric "'e2'"             "\\N"
+tf CleanNumeric "'E2'"             "\\N"
+tf CleanNumeric "'.e'"             "\\N"
+tf CleanNumeric "'.E'"             "\\N"
+tf CleanNumeric "'1e'"             "\\N"
+tf CleanNumeric "'1E'"             "\\N"
+tf CleanNumeric "'1.e'"            "\\N"
+tf CleanNumeric "'1.E'"            "\\N"
+tf CleanNumeric "'.e2'"            "\\N"
+tf CleanNumeric "'.E2'"            "\\N"
 tf CleanNumeric "'9999999999'"     "9999999999"
 tf CleanNumeric "'-9999999999'"    "-9999999999"
 tf CleanNumeric "'123'"            "123"

--- a/test/sql-test.sh
+++ b/test/sql-test.sh
@@ -48,6 +48,7 @@ tf "" "select array_agg(i) from \
 tf CleanInt "'.'"              "\\N"
 tf CleanInt "''"               "\\N"
 tf CleanInt "'-'"              "\\N"
+tf CleanInt "'+'"              "\\N"
 tf CleanInt "'foobar'"         "\\N"
 tf CleanInt "'9999999999'"     "\\N"  # out of range, returns null
 tf CleanInt "'-2147483649'"    "\\N"  # one less than the smallest possible int
@@ -56,15 +57,19 @@ tf CleanInt "'-2147483648'"    "-2147483648"  # smallest possible int
 tf CleanInt "'123.456'"        "123"  # round down
 tf CleanInt "'456.789'"        "457"  # round up
 tf CleanInt "'  456.789  '"    "457"  # round up with trimming
+tf CleanInt "'+42'"            "42"   # allowed plus symbol
+tf CleanInt "'+42.123'"        "42"
 
 # CleanNumeric
 tf CleanNumeric "'.'"              "\\N"
 tf CleanNumeric "''"               "\\N"
 tf CleanNumeric "'-'"              "\\N"
+tf CleanNumeric "'+'"              "\\N"
 tf CleanNumeric "'foobar'"         "\\N"
 tf CleanNumeric "'9999999999'"     "9999999999"
 tf CleanNumeric "'-9999999999'"    "-9999999999"
 tf CleanNumeric "'123'"            "123"
+tf CleanNumeric "'+42'"            "42"
 tf CleanNumeric "'123.456'"        "123.456"
 tf CleanNumeric "'456.789'"        "456.789"
 tf CleanNumeric "'  456.789   '"   "456.789"

--- a/test/sql-test.sh
+++ b/test/sql-test.sh
@@ -47,6 +47,7 @@ tf "" "select array_agg(i) from \
 # CleanInt
 tf CleanInt "'.'"              "\\N"
 tf CleanInt "''"               "\\N"
+tf CleanInt "'-'"              "\\N"
 tf CleanInt "'foobar'"         "\\N"
 tf CleanInt "'9999999999'"     "\\N"  # out of range, returns null
 tf CleanInt "'-2147483649'"    "\\N"  # one less than the smallest possible int
@@ -59,6 +60,7 @@ tf CleanInt "'  456.789  '"    "457"  # round up with trimming
 # CleanNumeric
 tf CleanNumeric "'.'"              "\\N"
 tf CleanNumeric "''"               "\\N"
+tf CleanNumeric "'-'"              "\\N"
 tf CleanNumeric "'foobar'"         "\\N"
 tf CleanNumeric "'9999999999'"     "9999999999"
 tf CleanNumeric "'-9999999999'"    "-9999999999"

--- a/test/sql-test.sh
+++ b/test/sql-test.sh
@@ -45,13 +45,12 @@ tf "" "select array_agg(i) from \
     "{0.00089832,0.00089832,0.00269495,0.00269495}"
 
 # CleanInt
+tf CleanInt "null"             "\\N"
 tf CleanInt "'.'"              "\\N"
 tf CleanInt "''"               "\\N"
 tf CleanInt "'-'"              "\\N"
 tf CleanInt "'+'"              "\\N"
 tf CleanInt "'foobar'"         "\\N"
-tf CleanInt "'9999999999'"     "\\N"  # out of range, returns null
-tf CleanInt "'-9999999999'"    "\\N"
 tf CleanInt "'e'"              "\\N"
 tf CleanInt "'E'"              "\\N"
 tf CleanInt "'e2'"             "\\N"
@@ -64,13 +63,17 @@ tf CleanInt "'1.e'"            "\\N"
 tf CleanInt "'1.E'"            "\\N"
 tf CleanInt "'.e2'"            "\\N"
 tf CleanInt "'.E2'"            "\\N"
+tf CleanInt "'a123'"           "\\N"
+tf CleanInt "'123a'"           "\\N"
+tf CleanInt "'9999999999'"     "\\N"  # out of range, returns null
+tf CleanInt "'-9999999999'"    "\\N"
 tf CleanInt "'123'"            "123"
 tf CleanInt "'+42'"            "42"   # allowed plus symbol
+tf CleanInt "'+42.123'"        "42"
 tf CleanInt "'123.456'"        "123"  # round down
 tf CleanInt "'456.789'"        "457"  # round up
-tf CleanInt "'  456.789  '"    "457"  # round up with trimming
+tf CleanInt "'  456.789   '"   "457"  # round up with trimming
 tf CleanInt "'456.789e2'"      "45679"  # int with exp, round up
-tf CleanInt "'+42.123'"        "42"
 # INT range check
 tf CleanInt "'-2147483649'"    "\\N"  # one less than the smallest possible int
 tf CleanInt "'2147483648'"     "\\N"  # one more than the largest possible int
@@ -79,6 +82,7 @@ tf CleanInt "'-2147483648'"    "-2147483648"  # smallest possible int
 
 
 # CleanNumeric
+tf CleanNumeric "null"             "\\N"
 tf CleanNumeric "'.'"              "\\N"
 tf CleanNumeric "''"               "\\N"
 tf CleanNumeric "'-'"              "\\N"
@@ -96,10 +100,13 @@ tf CleanNumeric "'1.e'"            "\\N"
 tf CleanNumeric "'1.E'"            "\\N"
 tf CleanNumeric "'.e2'"            "\\N"
 tf CleanNumeric "'.E2'"            "\\N"
+tf CleanNumeric "'a123'"           "\\N"
+tf CleanNumeric "'123a'"           "\\N"
 tf CleanNumeric "'9999999999'"     "9999999999"
 tf CleanNumeric "'-9999999999'"    "-9999999999"
 tf CleanNumeric "'123'"            "123"
 tf CleanNumeric "'+42'"            "42"
+tf CleanNumeric "'+42.123'"        "42.123"
 tf CleanNumeric "'123.456'"        "123.456"
 tf CleanNumeric "'456.789'"        "456.789"
 tf CleanNumeric "'  456.789   '"   "456.789"


### PR DESCRIPTION
Current implementation crashes if the value is a single '-' or '+' char, or in other edge cases like 'e2'.
The code has been rewritten from https://github.com/openmaptiles/openmaptiles/pull/785#issuecomment-601395012 suggestion based on @RhodiumToad suggested code.

This change was fully tested locally using `npm test`

P.S. Admins, please enable [travis-ci build](https://travis-ci.org/github/openmaptiles/postgis-vt-util) for this repo.

cc @jsanz @sfkeller 